### PR TITLE
Agent readiness: robots.txt, well-known discovery, Cloudflare worker proxy

### DIFF
--- a/.well-known/agent-skills/api-reference/SKILL.md
+++ b/.well-known/agent-skills/api-reference/SKILL.md
@@ -1,0 +1,28 @@
+# Apple Health Data — API Reference
+
+Describes the Mac Health Analyzer REST-style API for fetching Apple Health commit history.
+
+## Endpoint
+
+`GET https://applehealthdata.com/commits`
+
+## Parameters
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| page | integer | 1 | Page number (1–200) |
+| per_page | integer | 10 | Results per page (1–50) |
+
+## Response
+
+Returns a JSON array of GitHub commit objects from the MacHealthAnalyzer repository.
+
+## Example
+
+```
+GET https://applehealthdata.com/commits?page=1&per_page=5
+```
+
+## Documentation
+
+Full documentation: https://applehealthdata.com/docs/api-reference.html

--- a/.well-known/agent-skills/index.json
+++ b/.well-known/agent-skills/index.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "api-reference",
+      "type": "skill-md",
+      "description": "How to query the Apple Health Data commits API endpoint",
+      "url": "https://applehealthdata.com/.well-known/agent-skills/api-reference/SKILL.md",
+      "digest": "sha256:7f8eea8a068d434efe2d1a3a02a96b444a56d59aea47d81fe0dc757b8f103e76"
+    }
+  ]
+}

--- a/.well-known/api-catalog
+++ b/.well-known/api-catalog
@@ -1,0 +1,13 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://applehealthdata.com/docs/api-reference.html",
+      "service-doc": [
+        {
+          "href": "https://applehealthdata.com/docs/api-reference.html",
+          "type": "text/html"
+        }
+      ]
+    }
+  ]
+}

--- a/.well-known/http-message-signatures-directory
+++ b/.well-known/http-message-signatures-directory
@@ -1,0 +1,9 @@
+{
+  "keys": [
+    {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "wd2gok_kwdlhDg6gVxqHCY9NMDWjqEpS7t3N9qO_yms"
+    }
+  ]
+}

--- a/cloudflare-worker/src/index.js
+++ b/cloudflare-worker/src/index.js
@@ -1,83 +1,129 @@
+// Cloudflare Worker for applehealthdata.com
+// - Serves /commits as a GitHub API proxy (existing behavior)
+// - Proxies everything else to the GitHub Pages origin
+// - Adds RFC 8288 Link response headers on HTML responses for agent discovery
+
+const GITHUB_PAGES_ORIGIN = 'https://krumjahn.github.io';
+
+// RFC 8288 Link header values advertised on HTML responses.
+// rel values: "service-doc" (RFC 8631), "sitemap" (IANA), "terms-of-service" (IANA),
+// "help" (IANA), "author" (IANA).
+const LINK_HEADER = [
+  '</docs/api-reference.html>; rel="service-doc"; type="text/html"',
+  '</docs/>; rel="help"; type="text/html"',
+  '</sitemap.xml>; rel="sitemap"; type="application/xml"',
+  '</privacy/>; rel="privacy-policy"; type="text/html"',
+  '</robots.txt>; rel="describedby"; type="text/plain"'
+].join(', ');
+
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
 
-    // Simple CORS + security: allow only your production origin (and localhost for testing)
-    const origin = request.headers.get('Origin') || '';
-    const allowedOrigins = new Set([
-      'https://applehealthdata.com',
-      'https://www.applehealthdata.com',
-      'http://localhost:8787'
-    ]);
-
-    const corsHeaders = {
-      'Access-Control-Allow-Origin': allowedOrigins.has(origin) ? origin : 'https://applehealthdata.com',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
-      'Access-Control-Max-Age': '86400'
-    };
-
-    if (request.method === 'OPTIONS') {
-      return new Response(null, { status: 204, headers: corsHeaders });
+    if (url.pathname === '/commits') {
+      return handleCommits(request, url, env);
     }
 
-    // Health check
-    if (url.pathname === '/' || url.pathname === '/health') {
-      return new Response(JSON.stringify({ ok: true }), {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-      });
-    }
-
-    // Proxy endpoint for commits
-    if (url.pathname !== '/commits') {
-      return new Response('Not Found', { status: 404, headers: corsHeaders });
-    }
-
-    const owner = env.GITHUB_OWNER;
-    const repo = env.GITHUB_REPO;
-
-    const page = clampInt(url.searchParams.get('page') ?? '1', 1, 200);
-    const perPage = clampInt(url.searchParams.get('per_page') ?? '10', 1, 50);
-
-    if (!env.GITHUB_TOKEN) {
-      return new Response(JSON.stringify({ error: 'Missing GitHub token' }), {
-        status: 500,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-      });
-    }
-
-    const ghUrl = `https://api.github.com/repos/${owner}/${repo}/commits?page=${page}&per_page=${perPage}`;
-
-    const ghRes = await fetch(ghUrl, {
-      headers: {
-        'Authorization': `Bearer ${env.GITHUB_TOKEN}`,
-        'User-Agent': 'applehealthdata-changelog-worker',
-        'Accept': 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28'
-      }
-    });
-
-    // Pass through rate limit headers (useful for debugging)
-    const rateHeaders = {
-      'X-RateLimit-Limit': ghRes.headers.get('X-RateLimit-Limit') || '',
-      'X-RateLimit-Remaining': ghRes.headers.get('X-RateLimit-Remaining') || '',
-      'X-RateLimit-Reset': ghRes.headers.get('X-RateLimit-Reset') || ''
-    };
-
-    const bodyText = await ghRes.text();
-
-    return new Response(bodyText, {
-      status: ghRes.status,
-      headers: {
-        ...corsHeaders,
-        ...rateHeaders,
-        'Content-Type': 'application/json',
-        // Cache at edge for 2 minutes to reduce GitHub API pressure
-        'Cache-Control': 'public, max-age=120'
-      }
-    });
+    return handleProxy(request, url);
   }
 };
+
+async function handleProxy(request, url) {
+  const originUrl = new URL(url.pathname + url.search, GITHUB_PAGES_ORIGIN);
+
+  const originReq = new Request(originUrl.toString(), {
+    method: request.method,
+    headers: stripHopByHop(request.headers),
+    body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
+    redirect: 'manual'
+  });
+
+  const originRes = await fetch(originReq);
+
+  const headers = new Headers(originRes.headers);
+  const contentType = headers.get('Content-Type') || '';
+
+  if (contentType.includes('text/html')) {
+    headers.set('Link', LINK_HEADER);
+  }
+
+  return new Response(originRes.body, {
+    status: originRes.status,
+    statusText: originRes.statusText,
+    headers
+  });
+}
+
+async function handleCommits(request, url, env) {
+  const origin = request.headers.get('Origin') || '';
+  const allowedOrigins = new Set([
+    'https://applehealthdata.com',
+    'https://www.applehealthdata.com',
+    'http://localhost:8787'
+  ]);
+
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': allowedOrigins.has(origin) ? origin : 'https://applehealthdata.com',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400'
+  };
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
+  const owner = env.GITHUB_OWNER;
+  const repo = env.GITHUB_REPO;
+
+  const page = clampInt(url.searchParams.get('page') ?? '1', 1, 200);
+  const perPage = clampInt(url.searchParams.get('per_page') ?? '10', 1, 50);
+
+  if (!env.GITHUB_TOKEN) {
+    return new Response(JSON.stringify({ error: 'Missing GitHub token' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+    });
+  }
+
+  const ghUrl = `https://api.github.com/repos/${owner}/${repo}/commits?page=${page}&per_page=${perPage}`;
+
+  const ghRes = await fetch(ghUrl, {
+    headers: {
+      'Authorization': `Bearer ${env.GITHUB_TOKEN}`,
+      'User-Agent': 'applehealthdata-changelog-worker',
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28'
+    }
+  });
+
+  const rateHeaders = {
+    'X-RateLimit-Limit': ghRes.headers.get('X-RateLimit-Limit') || '',
+    'X-RateLimit-Remaining': ghRes.headers.get('X-RateLimit-Remaining') || '',
+    'X-RateLimit-Reset': ghRes.headers.get('X-RateLimit-Reset') || ''
+  };
+
+  const bodyText = await ghRes.text();
+
+  return new Response(bodyText, {
+    status: ghRes.status,
+    headers: {
+      ...corsHeaders,
+      ...rateHeaders,
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=120'
+    }
+  });
+}
+
+function stripHopByHop(headers) {
+  const out = new Headers(headers);
+  const hopByHop = ['connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization',
+    'te', 'trailers', 'transfer-encoding', 'upgrade', 'host'];
+  for (const h of hopByHop) out.delete(h);
+  out.set('Host', new URL(GITHUB_PAGES_ORIGIN).host);
+  return out;
+}
 
 function clampInt(value, min, max) {
   const n = parseInt(String(value), 10);

--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -2,6 +2,14 @@ name = "applehealthdata-changelog"
 main = "src/index.js"
 compatibility_date = "2026-01-19"
 
+# Route all site traffic through the worker so we can inject Link headers
+# on HTML responses. Requires applehealthdata.com to be on Cloudflare DNS
+# with the A/CNAME record proxied (orange cloud).
+routes = [
+  { pattern = "applehealthdata.com/*", zone_name = "applehealthdata.com" },
+  { pattern = "www.applehealthdata.com/*", zone_name = "applehealthdata.com" }
+]
+
 [vars]
 GITHUB_OWNER = "krumjahn"
 GITHUB_REPO = "MacHealthAnalyzer"

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,28 @@
+# robots.txt for applehealthdata.com
+# https://www.rfc-editor.org/rfc/rfc9309
+
+# Default: allow all crawlers, block tracking/infra paths
+User-agent: *
+Allow: /
+Disallow: /go/
+Disallow: /cloudflare-worker/
+Disallow: /*.bak$
+
+# AI training + search crawlers — allow full site indexing and search,
+# but opt out of training data use
+User-agent: GPTBot
+User-agent: OAI-SearchBot
+User-agent: anthropic-ai
+User-agent: Claude-Web
+User-agent: Google-Extended
+User-agent: Amazonbot
+User-agent: Applebot-Extended
+User-agent: Bytespider
+User-agent: CCBot
+Allow: /
+Disallow: /go/
+Disallow: /cloudflare-worker/
+Disallow: /*.bak$
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+
+Sitemap: https://applehealthdata.com/sitemap.xml


### PR DESCRIPTION
## Summary

- Add `robots.txt` with explicit AI crawler rules (GPTBot, Claude-Web, Google-Extended, Amazonbot, CCBot, etc.) and Content-Signal directives (`ai-train=no, search=yes, ai-input=yes`)
- Publish Web Bot Auth JWKS at `/.well-known/http-message-signatures-directory` (Ed25519 public key)
- Publish RFC 9727 API catalog at `/.well-known/api-catalog`
- Publish agent skills discovery index at `/.well-known/agent-skills/index.json` + `api-reference/SKILL.md`
- Rewrite Cloudflare Worker to proxy the full site and inject RFC 8288 `Link:` response headers on HTML responses
- Add `wrangler.toml` routes binding the worker to `applehealthdata.com/*` and `www.applehealthdata.com/*`

## After merging

1. GitHub Pages will serve all new `/.well-known/` files and `robots.txt`
2. Run `cd cloudflare-worker && npx wrangler deploy` to activate the worker routes (DNS is already live on Cloudflare)
3. Verify: `curl -sI https://applehealthdata.com/ | grep -iE 'server|cf-ray|link:'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)