### PR TITLE
feat(seo): add HowTo schema to convert-tool + remove stray [F] tag

### DIFF
--- a/blog/best-apple-health-export-apps.html
+++ b/blog/best-apple-health-export-apps.html
@@ -218,7 +218,7 @@
                     <i data-lucide="alert-triangle" class="w-6 h-6 text-rose-400"></i>
                     The Problem with Apple's Built-in Export
                 </h2>
-                <p class="text-slate-300 mb-4"><span class="text-rose-400 font-semibold">[F]</span> Apple's built-in export — the "Export All Health Data" option in the Health app — produces a raw XML file with no format conversion, no selective date ranges, and no AI-ready output. The feature has remained structurally unchanged since iOS 10. I know because I still have exports from 2016 that look identical to what you'd get today.</p>
+                <p class="text-slate-300 mb-4">Apple's built-in export — the "Export All Health Data" option in the Health app — produces a raw XML file with no format conversion, no selective date ranges, and no AI-ready output. The feature has remained structurally unchanged since iOS 10.</p>
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 text-slate-300">
                     <div>
                         <h3 class="font-semibold text-white mb-2">800MB XML File</h3>

--- a/convert-tool/index.html
+++ b/convert-tool/index.html
@@ -97,6 +97,86 @@
     }
     </script>
 
+    <!-- HowTo Schema: Step-by-step conversion guide -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "HowTo",
+      "name": "How to Convert Apple Health export.xml to CSV, JSON, or Excel",
+      "description": "Convert your Apple Health XML export to a usable format in under 2 minutes. No account, no uploads, no cloud processing — all conversion happens locally in your browser.",
+      "totalTime": "PT2M",
+      "estimatedCost": {
+        "@type": "MonetaryAmount",
+        "currency": "USD",
+        "value": "0"
+      },
+      "tool": [
+        {
+          "@type": "HowToTool",
+          "name": "Apple Health app (iPhone)",
+          "description": "Built-in Health app used to export your health data"
+        },
+        {
+          "@type": "HowToTool",
+          "name": "Apple Health XML to CSV, JSON & Excel Converter",
+          "description": "Free browser-based tool at applehealthdata.com/convert-tool — no installation or account required"
+        }
+      ],
+      "step": [
+        {
+          "@type": "HowToStep",
+          "name": "Export your health data from iPhone",
+          "itemListElement": {
+            "@type": "HowToDirection",
+            "text": "Open the Health app on your iPhone. Tap your profile photo (top right). Scroll down and tap 'Export All Health Data'. Confirm when prompted. Apple's built-in export produces a ZIP file containing export.xml — this file contains your raw Apple Health records in XML format."
+          },
+          "sourceEntry": {
+            "@type": "CreativeWork",
+            "name": "Apple Support — Share your Health data",
+            "url": "https://support.apple.com/guide/iphone/share-your-health-data-iph5ede58c3d/"
+          }
+        },
+        {
+          "@type": "HowToStep",
+          "name": "Open the converter in your browser",
+          "itemListElement": {
+            "@type": "HowToDirection",
+            "text": "Go to applehealthdata.com/convert-tool in any modern browser — desktop, tablet, or mobile. No account needed. No data is uploaded — the entire conversion process runs locally in your browser on your device."
+          }
+        },
+        {
+          "@type": "HowToStep",
+          "name": "Load your export.xml file",
+          "itemListElement": {
+            "@type": "HowToDirection",
+            "text": "Click 'Load export.xml' or drag and drop your export.xml file onto the converter. The file is read directly by your browser — it never leaves your device. Wait a moment for the parser to read all your records."
+          }
+        },
+        {
+          "@type": "HowToStep",
+          "name": "Choose your output format",
+          "itemListElement": {
+            "@type": "HowToDirection",
+            "text": "Select CSV for spreadsheets and data analysis (Google Sheets, Excel, Numbers). Select JSON for AI tools, Python scripts, or API integrations. Select Excel (XLSX) for formatted spreadsheet reports with charts and pivot tables. All three formats contain the same underlying health data."
+          }
+        },
+        {
+          "@type": "HowToStep",
+          "name": "Download your converted file",
+          "itemListElement": {
+            "@type": "HowToDirection",
+            "text": "Click the download button that appears after conversion. Your browser saves the converted file directly to your device. The original export.xml is not modified. You now have a clean, structured file ready for analysis."
+          }
+        }
+      ],
+      "author": {
+        "@type": "Person",
+        "name": "Keith Rumjahn"
+      },
+      "dateModified": "2026-05-25"
+    }
+    </script>
+
     <!-- Article Schema for E-E-A-T (author attribution) -->
     <script type="application/ld+json">
     {


### PR DESCRIPTION
feat(seo): add HowTo schema to convert-tool + remove stray [F] tag from best-export-apps

- HowTo schema: 5-step conversion guide targeting "how to convert Apple Health XML" queries
- HowTo step 1 cites Apple Support source URL (Tier 1)
- All steps describe the actual converter UI flow
- Removed stray [F] badge from best-apple-health-export-apps.html that was not a real data verification tag