### PR TITLE
Add /docs/mcp-server.html (Claude Desktop + Cursor install)

### DIFF
--- a/docs/ai-analysis.html
+++ b/docs/ai-analysis.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/api-reference.html
+++ b/docs/api-reference.html
@@ -239,6 +239,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html" class="active">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/backup.html
+++ b/docs/backup.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -249,6 +249,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/convert-tool.html
+++ b/docs/convert-tool.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/export-health-data.html
+++ b/docs/export-health-data.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -238,6 +238,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>
@@ -277,6 +278,14 @@
                             <h3 class="text-white font-bold m-0">Convert Tool</h3>
                         </div>
                         <p class="text-slate-400 text-sm m-0">Convert Apple Health XML to CSV, JSON, or Excel directly in your browser.</p>
+                    </a>
+
+                    <a href="/docs/mcp-server.html" class="doc-card block no-underline">
+                        <div class="flex items-center gap-3 mb-2">
+                            <i data-lucide="plug-zap" class="w-5 h-5 text-fuchsia-400"></i>
+                            <h3 class="text-white font-bold m-0">MCP Server (Claude, Cursor)</h3>
+                        </div>
+                        <p class="text-slate-400 text-sm m-0">Install <code class="bg-white/5 px-1 rounded">health-analyzer-mcp</code> and plug Apple Health into Claude Desktop, Cursor, and any MCP client.</p>
                     </a>
 
                     <a href="/docs/openclaw.html" class="doc-card block no-underline">

--- a/docs/mac-app.html
+++ b/docs/mac-app.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/mcp-server.html
+++ b/docs/mcp-server.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MCP Server — Health Data Export & AI Analyzer</title>
+    <meta name="description" content="Install and use the health-analyzer-mcp Model Context Protocol server with Claude Desktop, Cursor, and other MCP clients. Query your Apple Health data with natural language — 100% local.">
+    <link rel="canonical" href="https://applehealthdata.com/docs/mcp-server.html">
+    <meta name="apple-itunes-app" content="app-id=6749297170">
+    <meta name="robots" content="index,follow">
+
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Health Data Export & Analyze">
+    <meta property="og:url" content="https://applehealthdata.com/docs/mcp-server.html">
+    <meta property="og:title" content="MCP Server — Health Data Export & AI Analyzer">
+    <meta property="og:description" content="Plug Apple Health into Claude Desktop, Cursor, and any MCP client via a local Model Context Protocol server.">
+    <meta property="og:image" content="https://applehealthdata.com/images/mac-app-screenshot-1.png">
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;700&display=swap');
+
+        :root { --glass-border: rgba(255, 255, 255, 0.08); --glass-bg: rgba(255, 255, 255, 0.03); }
+
+        body {
+            font-family: 'Plus Jakarta Sans', sans-serif;
+            background-color: #020617;
+            color: #f8fafc;
+        }
+
+        .font-mono { font-family: 'JetBrains Mono', monospace; }
+
+        .docs-sidebar {
+            position: fixed; top: 0; left: 0; width: 280px; height: 100vh;
+            background: #0f172a; border-right: 1px solid var(--glass-border);
+            overflow-y: auto; z-index: 40; transition: transform 0.3s ease;
+        }
+        .docs-sidebar a { display: block; padding: 8px 16px 8px 24px; color: #94a3b8; font-size: 0.875rem; border-radius: 6px; margin: 1px 8px; transition: all 0.15s ease; text-decoration: none; }
+        .docs-sidebar a:hover { color: #e2e8f0; background: rgba(255, 255, 255, 0.05); }
+        .docs-sidebar a.active { color: #fff; background: rgba(244, 63, 94, 0.15); border-left: 2px solid #f43f5e; padding-left: 22px; }
+        .docs-sidebar .section-label { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: #64748b; padding: 20px 24px 6px; }
+
+        .docs-main { margin-left: 280px; min-height: 100vh; }
+
+        .sidebar-toggle { display: none; position: fixed; bottom: 20px; right: 20px; z-index: 50; background: #f43f5e; color: white; border: none; border-radius: 50%; width: 48px; height: 48px; cursor: pointer; box-shadow: 0 4px 12px rgba(244, 63, 94, 0.4); }
+
+        @media (max-width: 768px) {
+            .docs-sidebar { transform: translateX(-100%); }
+            .docs-sidebar.open { transform: translateX(0); }
+            .docs-main { margin-left: 0; }
+            .sidebar-toggle { display: flex; align-items: center; justify-content: center; }
+        }
+
+        .doc-content h1 { font-size: 2rem; font-weight: 800; margin-bottom: 1rem; color: #fff; }
+        .doc-content h2 { font-size: 1.5rem; font-weight: 700; margin-top: 2.5rem; margin-bottom: 0.75rem; color: #fff; padding-bottom: 0.5rem; border-bottom: 1px solid var(--glass-border); }
+        .doc-content h3 { font-size: 1.125rem; font-weight: 600; margin-top: 1.5rem; margin-bottom: 0.5rem; color: #e2e8f0; }
+        .doc-content p { color: #94a3b8; line-height: 1.75; margin-bottom: 1rem; }
+        .doc-content ul, .doc-content ol { color: #94a3b8; margin-bottom: 1rem; padding-left: 1.5rem; }
+        .doc-content li { margin-bottom: 0.5rem; line-height: 1.6; }
+        .doc-content strong { color: #e2e8f0; }
+        .doc-content code { font-family: 'JetBrains Mono', monospace; background: rgba(255,255,255,0.06); padding: 2px 6px; border-radius: 4px; font-size: 0.85em; color: #f0abfc; }
+        .doc-content pre { background: #0c0a09; border: 1px solid var(--glass-border); border-radius: 8px; padding: 16px; overflow-x: auto; margin-bottom: 1rem; }
+        .doc-content pre code { background: none; padding: 0; color: #a5f3fc; }
+        .doc-content a { color: #f43f5e; text-decoration: underline; text-underline-offset: 2px; }
+        .doc-content a:hover { color: #fb7185; }
+        .doc-content table { width: 100%; border-collapse: collapse; margin-bottom: 1rem; }
+        .doc-content th { text-align: left; padding: 10px 12px; border-bottom: 2px solid #1e293b; color: #e2e8f0; font-size: 0.85rem; font-weight: 600; }
+        .doc-content td { padding: 10px 12px; border-bottom: 1px solid #1e293b; color: #94a3b8; font-size: 0.875rem; }
+        .doc-content blockquote { border-left: 3px solid #f43f5e; padding: 12px 16px; margin: 1rem 0; background: rgba(244, 63, 94, 0.05); border-radius: 0 8px 8px 0; }
+        .doc-content blockquote p { color: #cbd5e1; margin-bottom: 0; }
+
+        .doc-card { background: var(--glass-bg); border: 1px solid var(--glass-border); border-radius: 12px; padding: 24px; transition: border-color 0.2s; }
+        .doc-card:hover { border-color: rgba(244, 63, 94, 0.3); }
+
+        .docs-search { background: rgba(255, 255, 255, 0.05); border: 1px solid var(--glass-border); border-radius: 8px; padding: 8px 12px; color: #e2e8f0; width: 100%; font-size: 0.875rem; outline: none; }
+        .docs-search::placeholder { color: #475569; }
+        .docs-search:focus { border-color: #f43f5e; }
+        .search-results { position:absolute; left:8px; right:8px; top:100%; margin-top:4px; background:#0f172a; border:1px solid rgba(255,255,255,0.12); border-radius:8px; overflow:hidden; z-index:100; max-height:360px; overflow-y:auto; }
+        .search-results a { display:block; padding:10px 14px; text-decoration:none; border-bottom:1px solid rgba(255,255,255,0.06); }
+        .search-results a:last-child { border-bottom:none; }
+        .search-results a:hover { background:rgba(255,255,255,0.06); }
+        .search-result-title { color:#e2e8f0; font-size:0.875rem; font-weight:600; }
+        .search-result-section { color:#94a3b8; font-size:0.75rem; margin-top:1px; }
+        .search-result-snippet { color:#64748b; font-size:0.75rem; margin-top:2px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+        .search-no-results { padding:12px 14px; color:#64748b; font-size:0.875rem; }
+    </style>
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-8SMQRLT4VS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-8SMQRLT4VS');
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;700&display=swap" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;700&display=swap"></noscript>
+</head>
+<body>
+
+    <aside class="docs-sidebar" id="sidebar">
+        <div class="p-4 border-b border-white/5">
+            <a href="/" class="flex items-center gap-2 text-white no-underline mb-3">
+                <div class="w-8 h-8 bg-gradient-to-tr from-rose-600 to-orange-500 rounded-lg flex items-center justify-center">
+                    <i data-lucide="activity" class="w-4 h-4 text-white"></i>
+                </div>
+                <span class="font-bold text-sm">Health Data Docs</span>
+            </a>
+            <div style="position:relative">
+                <input type="text" class="docs-search" placeholder="Search docs..." id="docs-search" autocomplete="off">
+                <div class="search-results" id="search-results" style="display:none"></div>
+            </div>
+        </div>
+
+        <nav class="py-3" id="docs-nav">
+            <div class="section-label">Overview</div>
+            <a href="/docs/">Welcome</a>
+            <a href="/docs/getting-started.html">Getting Started</a>
+
+            <div class="section-label">iPhone App</div>
+            <a href="/docs/export-health-data.html">Export Apple Health Data</a>
+            <a href="/docs/wifi-sync.html">iPhone-to-Mac Sync</a>
+            <a href="/docs/widgets.html">Home Screen Widget</a>
+
+            <div class="section-label">Mac App</div>
+            <a href="/docs/mac-app.html">Mac App Overview</a>
+            <a href="/docs/convert-tool.html">Convert XML to CSV/JSON/XLSX</a>
+            <a href="/docs/ai-analysis.html">AI Analysis</a>
+            <a href="/docs/backup.html">Apple Health Backup</a>
+
+            <div class="section-label">Sync Destinations</div>
+            <a href="/docs/sync-dropbox.html">Dropbox</a>
+            <a href="/docs/sync-nextcloud.html">Nextcloud / WebDAV</a>
+            <a href="/docs/sync-home-assistant.html">Home Assistant</a>
+            <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
+
+            <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html" class="active">MCP Server (Claude, Cursor)</a>
+            <a href="/docs/openclaw.html">OpenClaw Integration</a>
+            <a href="/docs/api-reference.html">API Reference</a>
+            <a href="/docs/workflows.html">Workflows & Automation</a>
+            <a href="/docs/prompts.html">Prompt Library</a>
+
+            <div class="section-label">Resources</div>
+            <a href="/docs/changelog.html">Changelog</a>
+            <a href="https://apps.apple.com/us/app/health-data-export-ai-analyzer/id6749297170" target="_blank">Download App</a>
+            <a href="https://github.com/krumjahn/applehealth" target="_blank">GitHub (Open Source)</a>
+        </nav>
+    </aside>
+
+    <button class="sidebar-toggle" onclick="document.getElementById('sidebar').classList.toggle('open')">
+        <i data-lucide="menu" class="w-5 h-5"></i>
+    </button>
+
+    <main class="docs-main">
+        <div class="max-w-3xl mx-auto px-6 py-16">
+            <div class="doc-content">
+                <h1>MCP Server (Claude Desktop, Cursor)</h1>
+                <p>Plug Apple Health into <strong>Claude Desktop</strong>, <strong>Cursor</strong>, and any other Model Context Protocol (MCP) client through the <code>health-analyzer-mcp</code> npm package. The MCP server runs locally on your Mac and talks to the Health Data AI Analyzer app over loopback — your health data never crosses the network.</p>
+
+                <blockquote>
+                    <p>This is the recommended integration for Claude Desktop and Cursor as of 2026. For the older OpenClaw workflow, see the <a href="/docs/openclaw.html">OpenClaw Integration</a> doc.</p>
+                </blockquote>
+
+                <h2>How It Works</h2>
+                <ol>
+                    <li><strong>Health Data AI Analyzer</strong> (Mac app) — imports your Apple Health export and runs a read-only API on <code>http://127.0.0.1:8765</code>.</li>
+                    <li><strong>health-analyzer-mcp</strong> (Node process spawned by your MCP client) — translates between the MCP protocol and the Mac app's local API.</li>
+                    <li><strong>MCP client</strong> (Claude Desktop, Cursor, etc.) — discovers the 11 tools, calls them based on your prompts, and returns natural-language answers.</li>
+                </ol>
+                <p>Everything happens on your Mac. Nothing leaves the machine except whatever response you explicitly ask your MCP client to reason about (and only to whichever AI provider that client is configured to use).</p>
+
+                <h2>Prerequisites</h2>
+                <ul>
+                    <li><strong>macOS</strong> — the Mac app is macOS-only</li>
+                    <li><strong>Node.js 18+</strong> — required to run the MCP server via <code>npx</code></li>
+                    <li><strong>Health Data AI Analyzer</strong> Mac app installed, with a dataset loaded and the <strong>Local API</strong> enabled in Settings</li>
+                    <li>An MCP client — Claude Desktop, Cursor, or any other</li>
+                </ul>
+
+                <h2>Setup — Claude Desktop</h2>
+
+                <h3>Step 1: Install the Mac App</h3>
+                <p>Download <a href="https://apps.apple.com/us/app/health-data-export-ai-analyzer/id6749297170">Health Data AI Analyzer</a> from the Mac App Store. Import an Apple Health XML export, or sync one from your iPhone using one of the <a href="/docs/wifi-sync.html">sync paths</a>.</p>
+
+                <h3>Step 2: Enable the Local API</h3>
+                <p>In the Mac app, open <strong>Settings</strong> and turn on <strong>Enable Local API for OpenClaw and scripts</strong>. The app writes an auth token to its sandboxed container; the MCP server auto-discovers this file.</p>
+
+                <h3>Step 3: Add the MCP Server to Claude Desktop Config</h3>
+                <p>Open your Claude Desktop config:</p>
+                <pre><code>~/Library/Application Support/Claude/claude_desktop_config.json</code></pre>
+                <p>Add the <code>health-analyzer</code> server entry. If the file doesn't exist, create it:</p>
+                <pre><code>{
+  "mcpServers": {
+    "health-analyzer": {
+      "command": "npx",
+      "args": ["-y", "health-analyzer-mcp"]
+    }
+  }
+}</code></pre>
+
+                <h3>Step 4: Restart Claude Desktop</h3>
+                <p>Quit Claude Desktop completely (Cmd+Q) and reopen it. The new server appears in the tools menu; you should see all 11 tools available.</p>
+
+                <h3>Step 5: Ask Claude About Your Health Data</h3>
+                <p>Open a new conversation and try one of these prompts:</p>
+                <pre><code>What were my step counts and sleep duration for the last 14 days?</code></pre>
+                <pre><code>Pull my HRV for the past 30 days and look for signs of overtraining
+or stress. Be explicit about your confidence level.</code></pre>
+                <pre><code>Give me yesterday's daily health brief and suggest one experiment
+for the coming week based on what you see.</code></pre>
+
+                <h2>Setup — Cursor</h2>
+                <p>Cursor uses the same MCP spec. Open <strong>Cursor Settings → MCP</strong> and add the same JSON snippet:</p>
+                <pre><code>{
+  "mcpServers": {
+    "health-analyzer": {
+      "command": "npx",
+      "args": ["-y", "health-analyzer-mcp"]
+    }
+  }
+}</code></pre>
+                <p>Save and the server activates immediately — no restart needed.</p>
+
+                <h2>The 11 Tools</h2>
+                <p>Every tool is read-only and annotated with the MCP <code>readOnlyHint: true</code> flag so clients know they're safe to call without user confirmation.</p>
+
+                <table>
+                    <thead>
+                        <tr><th>Tool</th><th>What it does</th><th>Inputs</th></tr>
+                    </thead>
+                    <tbody>
+                        <tr><td><code>get_status</code></td><td>Check whether the local API is running and whether a dataset is loaded.</td><td>None</td></tr>
+                        <tr><td><code>list_metrics</code></td><td>List the health metric types currently loaded in the app.</td><td>None</td></tr>
+                        <tr><td><code>get_health_summary</code></td><td>Overview of all loaded health metrics.</td><td><code>start_date</code>, <code>end_date</code></td></tr>
+                        <tr><td><code>get_steps</code></td><td>Daily step counts, averages, and totals.</td><td><code>start_date</code>, <code>end_date</code>, <code>limit</code></td></tr>
+                        <tr><td><code>get_sleep</code></td><td>Sleep duration and stage breakdown (deep, REM, core).</td><td><code>start_date</code>, <code>end_date</code>, <code>limit</code></td></tr>
+                        <tr><td><code>get_heart_rate</code></td><td>Heart rate, resting heart rate, and HRV trends over time.</td><td><code>start_date</code>, <code>end_date</code></td></tr>
+                        <tr><td><code>get_hrv</code></td><td>Heart rate variability and recovery trends.</td><td><code>start_date</code>, <code>end_date</code>, <code>limit</code></td></tr>
+                        <tr><td><code>get_weight</code></td><td>Weight measurements and trends.</td><td><code>start_date</code>, <code>end_date</code>, <code>limit</code></td></tr>
+                        <tr><td><code>get_workouts</code></td><td>Workout history including type, duration, and calories burned.</td><td><code>start_date</code>, <code>end_date</code>, <code>limit</code></td></tr>
+                        <tr><td><code>get_vo2max</code></td><td>VO2 max (cardio fitness) measurements and fitness level.</td><td><code>start_date</code>, <code>end_date</code>, <code>limit</code></td></tr>
+                        <tr><td><code>get_daily_health_brief</code></td><td>Yesterday's sleep, steps, workouts, and recovery context versus your recent baseline.</td><td><code>date</code> (optional)</td></tr>
+                    </tbody>
+                </table>
+
+                <h2>Optional Environment Variables</h2>
+                <p>The MCP server auto-discovers the auth token from the Mac app's sandboxed container. You should never need to set these — they only exist as escape hatches for non-standard installations:</p>
+
+                <table>
+                    <thead><tr><th>Variable</th><th>Purpose</th></tr></thead>
+                    <tbody>
+                        <tr><td><code>HEALTH_ANALYZER_TOKEN</code></td><td>Set the token value directly, skipping file lookup.</td></tr>
+                        <tr><td><code>HEALTH_ANALYZER_TOKEN_FILE</code></td><td>Absolute path to a <code>local-api-token.txt</code> file in a non-default location.</td></tr>
+                    </tbody>
+                </table>
+
+                <h2>Troubleshooting</h2>
+
+                <h3>"Cannot connect to Health Data AI Analyzer"</h3>
+                <p>The Mac app is not running, or the Local API is not enabled. Open the Mac app, go to <strong>Settings</strong>, and confirm <strong>Enable Local API for OpenClaw and scripts</strong> is on. Then call <code>get_status</code> from your MCP client to confirm the connection.</p>
+
+                <h3>"Token not found" or 401 errors</h3>
+                <p>The server couldn't find the auth token file. Run <code>get_status</code> — the response includes the paths it searched. If the file exists at one of those paths but the server still can't read it, your shell may have restricted filesystem permissions; try setting <code>HEALTH_ANALYZER_TOKEN_FILE</code> explicitly.</p>
+
+                <h3>Tools don't show up in Claude Desktop</h3>
+                <p>Confirm Claude Desktop was fully restarted (Cmd+Q, not just close-window). If the issue persists, check the Claude Desktop logs at <code>~/Library/Logs/Claude/</code> for MCP startup errors. The most common cause is a missing Node.js install — run <code>node --version</code> in Terminal; you need 18+.</p>
+
+                <h3>Slow first response</h3>
+                <p>The first call after a restart may take several seconds because <code>npx</code> downloads the latest <code>health-analyzer-mcp</code> package. Subsequent calls reuse the cached package and are near-instant.</p>
+
+                <h2>Privacy</h2>
+                <p>The MCP server is built around the same rule as the rest of the app: your health data stays on your Mac.</p>
+                <ul>
+                    <li><strong>Loopback only</strong> — the server only ever connects to <code>127.0.0.1:8765</code>; it has no network code that could reach the public internet.</li>
+                    <li><strong>Read-only</strong> — all 11 tools are read-only; the server cannot modify, delete, or write to your health records.</li>
+                    <li><strong>Token-gated</strong> — most local API routes require the auth token, which is generated by the Mac app and only readable by your user account.</li>
+                    <li><strong>Open source</strong> — the entire server is <a href="https://github.com/krumjahn/MacHealthAnalyzer/tree/main/mcp-server">~330 lines of MIT-licensed Node</a> on GitHub. Auditable in 10 minutes.</li>
+                </ul>
+                <p>The only data that ever leaves your Mac is whatever response your AI assistant asks to reason about — and only to the AI provider you've configured in your MCP client.</p>
+
+                <h2>Resources</h2>
+                <ul>
+                    <li><a href="https://www.npmjs.com/package/health-analyzer-mcp">npm: health-analyzer-mcp</a></li>
+                    <li><a href="https://github.com/krumjahn/MacHealthAnalyzer/tree/main/mcp-server">Source on GitHub</a></li>
+                    <li><a href="https://registry.modelcontextprotocol.io/v0/servers?search=health-analyzer-mcp">Official MCP Registry listing</a></li>
+                    <li><a href="/apple-health-mcp/">Landing page: Apple Health MCP server</a></li>
+                    <li><a href="/docs/api-reference.html">Underlying local API reference</a></li>
+                </ul>
+            </div>
+        </div>
+    </main>
+
+    <script>
+        let searchIndex = null;
+
+        async function loadIndex() {
+          if (searchIndex) return searchIndex;
+          const r = await fetch('/docs/search-index.json');
+          searchIndex = await r.json();
+          return searchIndex;
+        }
+
+        function highlight(text, q) {
+          if (!q) return text;
+          var escaped = q.replace(/[-.*+?^${}()|[\]\\]/g, '\\$&');
+          var re = new RegExp('(' + escaped + ')', 'gi');
+          return text.replace(re, '<mark style="background:rgba(244,63,94,0.25);color:#fda4af;border-radius:2px">$1</mark>');
+        }
+        const searchInput = document.getElementById('docs-search');
+        const resultsBox = document.getElementById('search-results');
+
+        searchInput.addEventListener('input', async function() {
+          const q = this.value.trim().toLowerCase();
+          const nav = document.getElementById('docs-nav');
+
+          if (!q) {
+            resultsBox.style.display = 'none';
+            nav.style.display = '';
+            return;
+          }
+
+          nav.style.display = 'none';
+          resultsBox.style.display = 'block';
+
+          const index = await loadIndex();
+          const results = [];
+
+          for (const page of index) {
+            if (page.title.toLowerCase().includes(q)) {
+              results.push({ url: page.url, title: page.title, section: '', snippet: page.intro });
+              continue;
+            }
+            for (const s of page.sections) {
+              const inHeading = s.heading.toLowerCase().includes(q);
+              const inSnippet = s.snippet.toLowerCase().includes(q);
+              if (inHeading || inSnippet) {
+                results.push({ url: page.url, title: page.title, section: s.heading, snippet: s.snippet });
+                break;
+              }
+            }
+          }
+
+          if (results.length === 0) {
+            resultsBox.innerHTML = '<div class="search-no-results">No results for &quot;' + this.value + '&quot;</div>';
+            return;
+          }
+
+          resultsBox.innerHTML = results.slice(0, 8).map(r => {
+            const sectionHtml = r.section ? '<div class="search-result-section">' + highlight(r.section, this.value.trim()) + '</div>' : '';
+            const snippetHtml = r.snippet ? '<div class="search-result-snippet">' + highlight(r.snippet.slice(0, 120), this.value.trim()) + '</div>' : '';
+            return '<a href="' + r.url + '"><div class="search-result-title">' + highlight(r.title, this.value.trim()) + '</div>' + sectionHtml + snippetHtml + '</a>';
+          }).join('');
+        }.bind(searchInput));
+
+        document.addEventListener('click', function(e) {
+          if (!e.target.closest('#search-results') && !e.target.closest('#docs-search')) {
+            resultsBox.style.display = 'none';
+            if (!searchInput.value.trim()) {
+              document.getElementById('docs-nav').style.display = '';
+            }
+          }
+        });
+
+        searchInput.addEventListener('keydown', function(e) {
+          if (e.key === 'Escape') {
+            this.value = '';
+            resultsBox.style.display = 'none';
+            document.getElementById('docs-nav').style.display = '';
+          }
+        });
+
+        lucide.createIcons();
+    </script>
+</body>
+</html>

--- a/docs/openclaw.html
+++ b/docs/openclaw.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html" class="active">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/prompts.html
+++ b/docs/prompts.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/search-index.json
+++ b/docs/search-index.json
@@ -413,6 +413,10 @@
         "snippet": ""
       },
       {
+        "heading": "MCP Server (Claude, Cursor)",
+        "snippet": ""
+      },
+      {
         "heading": "OpenClaw Integration",
         "snippet": ""
       },
@@ -522,6 +526,85 @@
       {
         "heading": "Related Pages",
         "snippet": "iPhone-to-Mac Sync AI Analysis API Reference OpenClaw Integration Convert XML to CSV/JSON/XLSX Getting Started"
+      }
+    ]
+  },
+  {
+    "title": "MCP Server",
+    "url": "/docs/mcp-server.html",
+    "intro": "Plug Apple Health into Claude Desktop , Cursor , and any other Model Context Protocol (MCP) client through the health-analyzer-mcp npm package. The MCP server runs locally on your Mac and talks to the",
+    "sections": [
+      {
+        "heading": "How It Works",
+        "snippet": "Health Data AI Analyzer (Mac app) — imports your Apple Health export and runs a read-only API on http://127.0.0.1:8765 . health-analyzer-mcp (Node process spawned by your MCP client) — translates betw"
+      },
+      {
+        "heading": "Prerequisites",
+        "snippet": "macOS — the Mac app is macOS-only Node.js 18+ — required to run the MCP server via npx Health Data AI Analyzer Mac app installed, with a dataset loaded and the Local API enabled in Settings An MCP cli"
+      },
+      {
+        "heading": "Setup — Claude Desktop",
+        "snippet": ""
+      },
+      {
+        "heading": "Step 1: Install the Mac App",
+        "snippet": "Download Health Data AI Analyzer from the Mac App Store. Import an Apple Health XML export, or sync one from your iPhone using one of the sync paths ."
+      },
+      {
+        "heading": "Step 2: Enable the Local API",
+        "snippet": "In the Mac app, open Settings and turn on Enable Local API for OpenClaw and scripts . The app writes an auth token to its sandboxed container; the MCP server auto-discovers this file."
+      },
+      {
+        "heading": "Step 3: Add the MCP Server to Claude Desktop Config",
+        "snippet": "Open your Claude Desktop config: ~/Library/Application Support/Claude/claude_desktop_config.json Add the health-analyzer server entry. If the file doesn't exist, create it: { \"mcpServers\": { \"health-a"
+      },
+      {
+        "heading": "Step 4: Restart Claude Desktop",
+        "snippet": "Quit Claude Desktop completely (Cmd+Q) and reopen it. The new server appears in the tools menu; you should see all 11 tools available."
+      },
+      {
+        "heading": "Step 5: Ask Claude About Your Health Data",
+        "snippet": "Open a new conversation and try one of these prompts: What were my step counts and sleep duration for the last 14 days? Pull my HRV for the past 30 days and look for signs of overtraining or stress. B"
+      },
+      {
+        "heading": "Setup — Cursor",
+        "snippet": "Cursor uses the same MCP spec. Open Cursor Settings → MCP and add the same JSON snippet: { \"mcpServers\": { \"health-analyzer\": { \"command\": \"npx\", \"args\": [\"-y\", \"health-analyzer-mcp\"] } } } Save and t"
+      },
+      {
+        "heading": "The 11 Tools",
+        "snippet": "Every tool is read-only and annotated with the MCP readOnlyHint: true flag so clients know they're safe to call without user confirmation. Tool What it does Inputs get_status Check whether the local A"
+      },
+      {
+        "heading": "Optional Environment Variables",
+        "snippet": "The MCP server auto-discovers the auth token from the Mac app's sandboxed container. You should never need to set these — they only exist as escape hatches for non-standard installations: Variable Pur"
+      },
+      {
+        "heading": "Troubleshooting",
+        "snippet": ""
+      },
+      {
+        "heading": "\"Cannot connect to Health Data AI Analyzer\"",
+        "snippet": "The Mac app is not running, or the Local API is not enabled. Open the Mac app, go to Settings , and confirm Enable Local API for OpenClaw and scripts is on. Then call get_status from your MCP client t"
+      },
+      {
+        "heading": "\"Token not found\" or 401 errors",
+        "snippet": "The server couldn't find the auth token file. Run get_status — the response includes the paths it searched. If the file exists at one of those paths but the server still can't read it, your shell may "
+      },
+      {
+        "heading": "Tools don't show up in Claude Desktop",
+        "snippet": "Confirm Claude Desktop was fully restarted (Cmd+Q, not just close-window). If the issue persists, check the Claude Desktop logs at ~/Library/Logs/Claude/ for MCP startup errors. The most common cause "
+      },
+      {
+        "heading": "Slow first response",
+        "snippet": "The first call after a restart may take several seconds because npx downloads the latest health-analyzer-mcp package. Subsequent calls reuse the cached package and are near-instant."
+      },
+      {
+        "heading": "Privacy",
+        "snippet": "The MCP server is built around the same rule as the rest of the app: your health data stays on your Mac. Loopback only — the server only ever connects to 127.0.0.1:8765 ; it has no network code that c"
+      },
+      {
+        "heading": "Resources",
+        "snippet": "npm: health-analyzer-mcp Source on GitHub Official MCP Registry listing Landing page: Apple Health MCP server Underlying local API reference"
       }
     ]
   },

--- a/docs/sync-dropbox.html
+++ b/docs/sync-dropbox.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/sync-home-assistant.html
+++ b/docs/sync-home-assistant.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/sync-nextcloud.html
+++ b/docs/sync-nextcloud.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/sync-rest-api.html
+++ b/docs/sync-rest-api.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html" class="active">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/widgets.html
+++ b/docs/widgets.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/wifi-sync.html
+++ b/docs/wifi-sync.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html">Workflows & Automation</a>

--- a/docs/workflows.html
+++ b/docs/workflows.html
@@ -224,6 +224,7 @@
             <a href="/docs/sync-rest-api.html">REST API / Webhook</a>
 
             <div class="section-label">Integrations</div>
+            <a href="/docs/mcp-server.html">MCP Server (Claude, Cursor)</a>
             <a href="/docs/openclaw.html">OpenClaw Integration</a>
             <a href="/docs/api-reference.html">API Reference</a>
             <a href="/docs/workflows.html" class="active">Workflows & Automation</a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -82,6 +82,13 @@
     <priority>0.6</priority>
   </url>
 
+  <url>
+    <loc>https://applehealthdata.com/docs/mcp-server.html</loc>
+    <lastmod>2026-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
   <!-- Guide Pages -->
   <url>
     <loc>https://applehealthdata.com/export-apple-health-data/</loc>


### PR DESCRIPTION
## Summary
- New \`/docs/mcp-server.html\` covering install for Claude Desktop and Cursor, all 11 read-only tools with input schemas, env var reference, troubleshooting, and privacy notes.
- Adds the page to the **Integrations** section of the sidebar across all 18 existing doc pages — listed above OpenClaw since MCP is the recommended path as of 2026.
- Adds a doc card on the \`/docs/\` welcome page alongside OpenClaw / API Reference / AI Analysis.
- Rebuilt \`search-index.json\` (19 pages, up from 18) so the new doc is searchable.
- Registers the URL in \`sitemap.xml\` at priority 0.8.

## Why
We just published \`health-analyzer-mcp@1.1.1\` to npm and the Official MCP Registry. The Claude/Cursor user base is growing fast — anyone arriving via the MCP listings, the npm install, or the \`/apple-health-mcp/\` landing page needs full docs on configuration and troubleshooting. This is the canonical setup reference everything else can link to.

## Test plan
- [ ] Visit deployed \`/docs/mcp-server.html\` and confirm the page renders with the dark theme and sidebar
- [ ] Click the new MCP link in the sidebar from any other doc page and confirm it highlights as active
- [ ] Search "MCP" in the docs search bar and confirm the new page appears in results
- [ ] Follow the Step 1–5 Claude Desktop instructions on a clean Mac with the Mac app running
- [ ] Confirm \`/docs/index.html\` shows the new MCP card

🤖 Generated with [Claude Code](https://claude.com/claude-code)