### PR TITLE
Reorg homepage nav: collapse integrations into a dropdown, surface MCP

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,13 +437,63 @@
                     <a href="/convert-tool/" class="px-4 py-2 text-sm font-medium text-slate-300 hover:text-white transition-colors rounded-lg hover:bg-white/5">Convert Tool</a>
                     <a href="#features" class="px-4 py-2 text-sm font-medium text-slate-300 hover:text-white transition-colors rounded-lg hover:bg-white/5">Features</a>
                     <a href="#specs" class="px-4 py-2 text-sm font-medium text-slate-300 hover:text-white transition-colors rounded-lg hover:bg-white/5">Specs</a>
-                    <a href="/apple-health-cli/" class="px-4 py-2 text-sm font-medium text-slate-300 hover:text-white transition-colors rounded-lg hover:bg-white/5 flex items-center gap-2"><i data-lucide="terminal" class="w-4 h-4"></i> CLI</a>
-                    <a href="/openclaw-apple-health/" class="px-4 py-2 text-sm font-medium text-slate-300 hover:text-white transition-colors rounded-lg hover:bg-white/5 flex items-center gap-2">
-                        <span class="text-base leading-none" role="img" aria-label="Lobster">🦞</span>
-                        OpenClaw
-                    </a>
-                    <a href="/apple-health-mcp/" class="px-4 py-2 text-sm font-medium text-slate-300 hover:text-white transition-colors rounded-lg hover:bg-white/5 flex items-center gap-2"><i data-lucide="plug-zap" class="w-4 h-4"></i> MCP</a>
-                    <a href="/workflows/" class="px-4 py-2 text-sm font-medium text-slate-300 hover:text-white transition-colors rounded-lg hover:bg-white/5 flex items-center gap-2"><i data-lucide="workflow" class="w-4 h-4"></i> Workflows</a>
+
+                    <!-- Integrations dropdown -->
+                    <div class="relative group">
+                        <button class="px-4 py-2 text-sm font-medium text-slate-300 hover:text-white transition-colors rounded-lg hover:bg-white/5 flex items-center gap-1.5">
+                            <i data-lucide="plug-zap" class="w-4 h-4"></i>
+                            Integrations
+                            <i data-lucide="chevron-down" class="w-3.5 h-3.5 opacity-70 group-hover:opacity-100 transition"></i>
+                        </button>
+                        <div class="absolute right-0 top-full pt-2 w-72 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-150 z-50">
+                            <div class="bg-slate-900/95 backdrop-blur-xl border border-white/10 rounded-xl shadow-2xl shadow-black/40 p-2">
+                                <a href="/apple-health-mcp/" class="flex items-start gap-3 px-3 py-2.5 rounded-lg text-slate-200 hover:bg-white/5 transition-colors group/item">
+                                    <i data-lucide="plug-zap" class="w-4 h-4 mt-0.5 text-fuchsia-400"></i>
+                                    <div>
+                                        <div class="text-sm font-semibold text-white">MCP Server <span class="ml-1 text-[10px] uppercase tracking-wider text-fuchsia-300 bg-fuchsia-500/10 px-1.5 py-0.5 rounded">New</span></div>
+                                        <div class="text-xs text-slate-400 mt-0.5">Claude Desktop, Cursor, any MCP client</div>
+                                    </div>
+                                </a>
+                                <a href="/apple-health-claude/" class="flex items-start gap-3 px-3 py-2.5 rounded-lg text-slate-200 hover:bg-white/5 transition-colors">
+                                    <i data-lucide="sparkles" class="w-4 h-4 mt-0.5 text-rose-400"></i>
+                                    <div>
+                                        <div class="text-sm font-semibold text-white">Apple Health + Claude</div>
+                                        <div class="text-xs text-slate-400 mt-0.5">Local API + Claude analysis workflow</div>
+                                    </div>
+                                </a>
+                                <a href="/apple-health-cli/" class="flex items-start gap-3 px-3 py-2.5 rounded-lg text-slate-200 hover:bg-white/5 transition-colors">
+                                    <i data-lucide="terminal" class="w-4 h-4 mt-0.5 text-cyan-400"></i>
+                                    <div>
+                                        <div class="text-sm font-semibold text-white">CLI</div>
+                                        <div class="text-xs text-slate-400 mt-0.5">Open-source command-line tool</div>
+                                    </div>
+                                </a>
+                                <a href="/openclaw-apple-health/" class="flex items-start gap-3 px-3 py-2.5 rounded-lg text-slate-200 hover:bg-white/5 transition-colors">
+                                    <span class="text-base leading-none mt-0.5" role="img" aria-label="Lobster">🦞</span>
+                                    <div>
+                                        <div class="text-sm font-semibold text-white">OpenClaw</div>
+                                        <div class="text-xs text-slate-400 mt-0.5">ClawHub skill for daily briefs</div>
+                                    </div>
+                                </a>
+                                <a href="/workflows/" class="flex items-start gap-3 px-3 py-2.5 rounded-lg text-slate-200 hover:bg-white/5 transition-colors">
+                                    <i data-lucide="workflow" class="w-4 h-4 mt-0.5 text-amber-400"></i>
+                                    <div>
+                                        <div class="text-sm font-semibold text-white">Workflows</div>
+                                        <div class="text-xs text-slate-400 mt-0.5">Automate daily briefs and reports</div>
+                                    </div>
+                                </a>
+                                <div class="border-t border-white/5 my-1"></div>
+                                <a href="/apple-health-ai/" class="flex items-start gap-3 px-3 py-2.5 rounded-lg text-slate-200 hover:bg-white/5 transition-colors">
+                                    <i data-lucide="brain" class="w-4 h-4 mt-0.5 text-purple-400"></i>
+                                    <div>
+                                        <div class="text-sm font-semibold text-white">All AI integrations</div>
+                                        <div class="text-xs text-slate-400 mt-0.5">Hub: Claude, OpenAI, Gemini, more</div>
+                                    </div>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+
                     <a href="/docs/" class="px-4 py-2 text-sm font-medium text-slate-300 hover:text-white transition-colors rounded-lg hover:bg-white/5 flex items-center gap-2"><i data-lucide="book-open" class="w-4 h-4"></i> Docs</a>
                     <a href="/docs/changelog.html" class="px-4 py-2 text-sm font-medium text-slate-300 hover:text-white transition-colors rounded-lg hover:bg-white/5 flex items-center gap-2"><i data-lucide="history" class="w-4 h-4"></i> Updates</a>
                     <a href="/go/website.html" target="_blank" rel="noopener" data-cta-location="nav" id="cta-nav-appstore" class="ml-4 bg-white text-black px-5 py-2.5 rounded-full text-sm font-bold hover:bg-slate-200 transition-all shadow-[0_0_20px_rgba(255,255,255,0.3)]">
@@ -467,12 +517,17 @@
                 <a href="/convert-tool/" class="px-4 py-3 text-sm font-medium text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors">Convert Tool</a>
                 <a href="#features" class="px-4 py-3 text-sm font-medium text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors mobile-menu-close">Features</a>
                 <a href="#specs" class="px-4 py-3 text-sm font-medium text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors mobile-menu-close">Specs</a>
-                <a href="/apple-health-cli/" class="px-4 py-3 text-sm font-medium text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors flex items-center gap-2"><i data-lucide="terminal" class="w-4 h-4"></i> CLI</a>
+
+                <div class="px-4 pt-3 pb-1 text-xs font-bold uppercase tracking-wider text-slate-500">Integrations</div>
+                <a href="/apple-health-mcp/" class="px-4 py-3 text-sm font-medium text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors flex items-center gap-2"><i data-lucide="plug-zap" class="w-4 h-4 text-fuchsia-400"></i> MCP Server <span class="ml-auto text-[10px] uppercase tracking-wider text-fuchsia-300 bg-fuchsia-500/10 px-1.5 py-0.5 rounded">New</span></a>
+                <a href="/apple-health-claude/" class="px-4 py-3 text-sm font-medium text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors flex items-center gap-2"><i data-lucide="sparkles" class="w-4 h-4 text-rose-400"></i> Apple Health + Claude</a>
+                <a href="/apple-health-cli/" class="px-4 py-3 text-sm font-medium text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors flex items-center gap-2"><i data-lucide="terminal" class="w-4 h-4 text-cyan-400"></i> CLI</a>
                 <a href="/openclaw-apple-health/" class="px-4 py-3 text-sm font-medium text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors flex items-center gap-2">
                     <span role="img" aria-label="Lobster">🦞</span> OpenClaw
                 </a>
-                <a href="/apple-health-mcp/" class="px-4 py-3 text-sm font-medium text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors flex items-center gap-2"><i data-lucide="plug-zap" class="w-4 h-4"></i> MCP</a>
-                <a href="/workflows/" class="px-4 py-3 text-sm font-medium text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors flex items-center gap-2"><i data-lucide="workflow" class="w-4 h-4"></i> Workflows</a>
+                <a href="/workflows/" class="px-4 py-3 text-sm font-medium text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors flex items-center gap-2"><i data-lucide="workflow" class="w-4 h-4 text-amber-400"></i> Workflows</a>
+                <a href="/apple-health-ai/" class="px-4 py-3 text-sm font-medium text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors flex items-center gap-2"><i data-lucide="brain" class="w-4 h-4 text-purple-400"></i> All AI integrations</a>
+                <div class="px-4 pt-3 pb-1 text-xs font-bold uppercase tracking-wider text-slate-500">Resources</div>
                 <a href="/docs/" class="px-4 py-3 text-sm font-medium text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors flex items-center gap-2"><i data-lucide="book-open" class="w-4 h-4"></i> Docs</a>
                 <a href="/docs/changelog.html" class="px-4 py-3 text-sm font-medium text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors flex items-center gap-2"><i data-lucide="history" class="w-4 h-4"></i> Updates</a>
             </div>


### PR DESCRIPTION
## Summary
- Desktop nav had 9 items + Get App and was at visual saturation; adding MCP would have pushed it past what fits cleanly. This PR collapses MCP / Claude / CLI / OpenClaw / Workflows into a single \"Integrations\" dropdown.
- MCP is the first item in the dropdown with a \"New\" badge since it's the recommended integration path now.
- Pure CSS hover dropdown (group-hover) — no JS framework, no extra dependencies.
- Mobile menu reorganized with section labels (\"Integrations\", \"Resources\") so the same items group naturally in the stacked list. Also adds the Apple Health + Claude link and an \"All AI integrations\" link that weren't in the mobile nav before.

## Net effect
- Desktop nav: 9 items → 6 items + Get App
- MCP is now reachable in one click from anywhere on the homepage
- Future integrations (Gemini, OpenAI, Smithery, etc.) have a natural home

## Test plan
- [ ] Hover over \"Integrations\" on desktop and confirm the dropdown opens, items are readable, MCP shows the New badge
- [ ] Click each dropdown item and confirm it navigates correctly
- [ ] Open the mobile menu (resize browser <768px) and confirm the section labels and grouping render cleanly
- [ ] Tab through the nav with keyboard to confirm dropdown is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)